### PR TITLE
Add support for advanced custom fields oembed field

### DIFF
--- a/inc/class-embed-privacy.php
+++ b/inc/class-embed-privacy.php
@@ -85,8 +85,16 @@ class Embed_Privacy {
 				return 0;
 			}, 10, 1 );
 		}
-		
-		\add_filter( 'embed_oembed_html', [ $this, 'replace_embeds' ], 10, 3 );
+
+		// filter embeds in text editor
+		add_filter( 'embed_oembed_html', [ $this, 'replace_embeds' ], 10, 3 );
+
+		/**
+		 * filter embeds with the advanced custom fields oembeds field
+		 *
+		 * @see https://www.advancedcustomfields.com/resources/oembed/
+		 */
+		add_filter( 'oembed_result', [ $this, 'replace_embeds' ], 10, 3 );
 	}
 	
 	/**


### PR DESCRIPTION
Thanks for the great plugin! I added support for the [Advanced Custom Fields](https://www.advancedcustomfields.com/) Plugin. Since it uses a different way to integrate oembeds, we have to use a different filter to get the job done.

Thanks also for the `embed_privacy_content` filter! It would be awesome to have it in the official WordPress repo soon 🤩