### PR TITLE
Fix typo in the second argument of strpos function

### DIFF
--- a/inc/class-fields.php
+++ b/inc/class-fields.php
@@ -431,7 +431,7 @@ class Fields {
 			if ( is_array( $value ) ) {
 				$value = $this->sanitize_array( $value );
 			}
-			else if ( strpos( $field['name'], 'regex' === false ) ) {
+			else if ( strpos( $field['name'], 'regex') === false ) {
 				$value = sanitize_text_field( wp_unslash( $value ) );
 			}
 			


### PR DESCRIPTION
I received a deprecation warning and while I noticed that the strpos function is malformed written.

`Deprecated: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in /application/web/app/plugins/embed-privacy/inc/class-fields.php on line 434
`

This pull request will fix it.