### PR TITLE
Add wrapper class to p element containing the checkbox to always load embed provider

### DIFF
--- a/assets/style/scss/embed-privacy.scss
+++ b/assets/style/scss/embed-privacy.scss
@@ -54,7 +54,7 @@
 	}
 	
 	label,
-	p:last-child {
+	.embed-privacy-input-wrapper {
 		margin: 0;
 	}
 	

--- a/inc/class-embed-privacy.php
+++ b/inc/class-embed-privacy.php
@@ -606,7 +606,7 @@ class Embed_Privacy {
 		
 		if ( $embed_provider_lowercase !== 'default' ) {
 			/* translators: the embed provider */
-			$content .= '<p><input id="' . esc_attr( $checkbox_id ) . '" type="checkbox" value="1" class="embed-privacy-input" data-embed-provider="' . esc_attr( $embed_provider_lowercase ) . '"><label for="' . esc_attr( $checkbox_id ) . '" class="embed-privacy-label" data-embed-provider="' . esc_attr( $embed_provider_lowercase ) . '">' . sprintf( esc_html__( 'Always display content from %s', 'embed-privacy' ), esc_html( $embed_provider ) ) . '</label></p>';
+			$content .= '<p class="embed-privacy-input-wrapper"><input id="' . esc_attr( $checkbox_id ) . '" type="checkbox" value="1" class="embed-privacy-input" data-embed-provider="' . esc_attr( $embed_provider_lowercase ) . '"><label for="' . esc_attr( $checkbox_id ) . '" class="embed-privacy-label" data-embed-provider="' . esc_attr( $embed_provider_lowercase ) . '">' . sprintf( esc_html__( 'Always display content from %s', 'embed-privacy' ), esc_html( $embed_provider ) ) . '</label></p>';
 		}
 		
 		/**


### PR DESCRIPTION
It is not a big deal to select the `p` via `p:last-child` but maybe a class would make it a little easier :)