### PR TITLE
Implement #152

### DIFF
--- a/inc/class-thumbnails.php
+++ b/inc/class-thumbnails.php
@@ -173,7 +173,7 @@ class Thumbnails {
 		$thumbnail_path = '';
 		$thumbnail_url = '';
 		
-        if ( strpos( $url, 'slideshare.net' ) !== false ) {
+		if ( strpos( $url, 'slideshare.net' ) !== false ) {
 			$id = preg_replace( '/.*\/embed_code\/key\//', '', $url );
 			
 			if ( strpos( $id, '?' ) !== false ) {
@@ -221,7 +221,7 @@ class Thumbnails {
 	 * @return	string The returned oEmbed HTML
 	 */
 	public function get_from_provider( $return, $data, $url ) {
-        if ( strpos( $url, 'slideshare.net' ) !== false ) {
+		if ( strpos( $url, 'slideshare.net' ) !== false ) {
 			// the thumbnail URL contains sizing parameters in the query string
 			// remove this to get the maximum resolution
 			$thumbnail_url = preg_replace( '/\?.*/', '', $data->thumbnail_url );

--- a/inc/class-thumbnails.php
+++ b/inc/class-thumbnails.php
@@ -105,12 +105,10 @@ class Thumbnails {
 
 						$missing_url = strpos( $post->post_content, $url ) === false;
 					}
-					if ( $missing_id && $missing_url ) {
-						if ( ! $this->is_in_use( $meta_value, $post_id, $global_metadata ) ) {
-							$this->delete( $meta_value );
-							delete_post_meta( $post_id, $meta_key );
-							delete_post_meta( $post_id, $meta_key . '_url' );
-						}
+					if ( $missing_id && $missing_url && ! $this->is_in_use( $meta_value, $post_id, $global_metadata ) ) {
+						$this->delete( $meta_value );
+						delete_post_meta( $post_id, $meta_key );
+						delete_post_meta( $post_id, $meta_key . '_url' );
 					}
 				}
 			}


### PR DESCRIPTION
The `check_orphaned` function had to be slightly tweaked.

Slideshare pages have URLs like this:

    https://www.slideshare.net/TheLazza/abel-il-sistema-di-build-della-nuova-caine

However, the embed URLs are like this:

    https://www.slideshare.net/slideshow/embed_code/key/zD5lpx0ASAuM2P

This implementation takes `zD5lpx0ASAuM2P` as ID. However, the ID does not appear in the post content, hence the URL needs to be checked as well.