### PR TITLE
:sparkles: Fine-grained control to disable provider

### DIFF
--- a/inc/class-embed-privacy.php
+++ b/inc/class-embed-privacy.php
@@ -708,6 +708,11 @@ class Embed_Privacy {
 	 * @return	string The overlay template
 	 */
 	public function get_output_template( $embed_provider, $embed_provider_lowercase, $output, $args = [] ) {
+		$disable_provider = apply_filters("embed_privacy_disable_provider", $embed_provider, $embed_provider_lowercase, $output, $args);
+		if ($disable_provider === true) {
+			return $output;
+		}
+		
 		if ( ! empty( $args['post_id'] ) ) {
 			$embed_post = \get_post( $args['post_id'] );
 			

--- a/inc/class-embed-privacy.php
+++ b/inc/class-embed-privacy.php
@@ -708,8 +708,8 @@ class Embed_Privacy {
 	 * @return	string The overlay template
 	 */
 	public function get_output_template( $embed_provider, $embed_provider_lowercase, $output, $args = [] ) {
-		$disable_provider = apply_filters("embed_privacy_disable_provider", $embed_provider, $embed_provider_lowercase, $output, $args);
-		if ($disable_provider === true) {
+		$disable_provider = apply_filters( "embed_privacy_disable_provider", $embed_provider, $embed_provider_lowercase, $output, $args );
+		if ( $disable_provider === true ) {
 			return $output;
 		}
 		


### PR DESCRIPTION
This pull request introduces a filter hook `embed_privacy_disable_provider` which is applied just as the very first statement in `get_output_template`.

```
public function get_output_template( $embed_provider, $embed_provider_lowercase, $output, $args = [] ) {
	$disable_provider = apply_filters("embed_privacy_disable_provider", $embed_provider, $embed_provider_lowercase, $output, $args);
	if ($disable_provider === true) {
		return $output;
	}
```
This filter allows fine-grained control on when to disable an embed provider. It applies _before_ the disabled-option from the Wordpress settings is checked (alternatively this could also be placed _after_ checking of disabled option).

Our use case is to disable embed privacy for a [Liveticker](https://de.wordpress.org/plugins/stklcode-liveticker/) which receives it's messages as Wordpress post via _Ajax_. In this case embed privacy doesn't work. 
The messages of the Liveticker can be recognized by the post type `scliveticker_tick`.
```
add_filter('embed_privacy_disable_provider', 'disable_embed_privacy_provider', 10, 4);
function disable_embed_privacy_provider($embed_provider, $embed_provider_lowercase, $output, $args = []) {
	$post_type = get_post_type();
	return $post_type == 'scliveticker_tick';
}
```

Other implementations of the filter may check the HTTP request or using the `wp_doing_ajax()` function (which wouldn't work in the actual Liveticker issue).